### PR TITLE
Préciser que l'Insee détient les droits de propriété intellectuelle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Authors@R: c(
   person("Pierre", "Lamarche", email = "pierre.lamarche@insee.fr", role = c("aut", "cre")),
   person("Lino", "Galiana", role = "ctb", email = "lino.galiana@insee.fr"),
   person("Olivier", "Meslin", role = "ctb", email = "olivier.meslin@insee.fr"),
-  person("Fidani", "Gilles", role = "ctb", email = "gilles.fidani@insee.fr")
+  person("Fidani", "Gilles", role = "ctb", email = "gilles.fidani@insee.fr"),
+  person(family = "Institut National de la Statistique et des Études Économiques", role = "cph")
   )
 Description: Internal package for Insee staff members willing to use R in order to exploit and analyse data produced by the institute. This package makes it possible to either download on-the-fly the date from the website, or load pre-processed data. It also provides a (so far non comprehensive) list of datasets available on the website.
 Depends: R (>= 3.5.0)

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2020 Pierre Lamarche
+Copyright 2020 Institut National de la Statistique et des Études Économiques
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
Une petite PR pour simplement être raccord au niveau des droits de propriété intellectuelle car c'est l'Insee qui les détient

réf : [article L. 113-9 du code la propriété intellectuelle](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006278890&cidTexte=LEGITEXT000006069414)